### PR TITLE
Fix /api/config.js route (cleanUrls) + Instagram messaging endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ Thumbs.db
 .omc/
 .vercel
 .env*
+*.bak
+# GDPR: salon outreach data stays out of git (see CLAUDE.md)
+OUTREACH-TARGETS.md

--- a/api/index.js
+++ b/api/index.js
@@ -200,7 +200,9 @@ module.exports = async function handler(req, res) {
   }
 
   // ── CONFIG (public, no auth) ──────────────────────────────
-  if (req.url.split('?')[0] === '/api/config.js' && req.method === 'GET') {
+  // Note: vercel.json `cleanUrls` 308-redirects /api/config.js -> /api/config,
+  // so accept both paths or GM_CONFIG never loads (breaks login + channel connect).
+  if (['/api/config.js', '/api/config'].includes(req.url.split('?')[0]) && req.method === 'GET') {
     res.setHeader('Content-Type', 'application/javascript');
     res.setHeader('Cache-Control', 'public, max-age=300');
     return res.status(200).send(

--- a/api/lib/instagram.js
+++ b/api/lib/instagram.js
@@ -6,6 +6,24 @@
 const { processMessage } = require('./whatsapp');
 
 /**
+ * Verify Instagram webhook (Meta requires this on setup).
+ * Falls back to the shared WhatsApp verify token if a dedicated one isn't set,
+ * since a single Meta app commonly reuses one verify token across products.
+ */
+function verifyWebhook(req, res) {
+  const mode        = req.query['hub.mode'];
+  const token       = req.query['hub.verify_token'];
+  const challenge   = req.query['hub.challenge'];
+  const verifyToken = process.env.INSTAGRAM_VERIFY_TOKEN || process.env.WHATSAPP_VERIFY_TOKEN;
+
+  if (mode === 'subscribe' && token === verifyToken) {
+    console.log('[Instagram] Webhook verified');
+    return res.status(200).send(challenge);
+  }
+  return res.status(403).json({ error: 'Forbidden' });
+}
+
+/**
  * Handle incoming Instagram webhook
  */
 async function handleWebhook(req, res, { business, creds, sendEscalationAlert, sendOwnerNotification }) {
@@ -29,7 +47,7 @@ async function handleWebhook(req, res, { business, creds, sendEscalationAlert, s
         // Fetch guest name from Instagram profile
         let guestName = null;
         try {
-          guestName = await getInstagramName(contactId);
+          guestName = await getInstagramName(contactId, creds?.instagram);
         } catch { /* non-critical */ }
 
         await processMessage({
@@ -52,13 +70,16 @@ async function handleWebhook(req, res, { business, creds, sendEscalationAlert, s
 
 /**
  * Send Instagram DM
+ * Uses the Instagram API with Instagram Login (graph.instagram.com).
+ * The IG-Login access token is scoped to the connected IG user, so we POST
+ * to /me/messages. Replies are only permitted within the 24h window that
+ * opens after a user messages the business.
  */
 async function sendInstagramMessage(recipientId, text, creds) {
   const accessToken = creds?.accessToken || process.env.META_ACCESS_TOKEN;
-  const igPageId    = creds?.pageId      || process.env.INSTAGRAM_PAGE_ID;
 
   const res = await fetch(
-    `https://graph.facebook.com/v18.0/${igPageId}/messages`,
+    `https://graph.instagram.com/v21.0/me/messages`,
     {
       method: 'POST',
       headers: {
@@ -68,7 +89,6 @@ async function sendInstagramMessage(recipientId, text, creds) {
       body: JSON.stringify({
         recipient: { id: recipientId },
         message: { text },
-        messaging_type: 'RESPONSE',
       }),
     }
   );
@@ -84,15 +104,16 @@ async function sendInstagramMessage(recipientId, text, creds) {
 
 /**
  * Fetch Instagram user's display name
+ * Looks up the Instagram-scoped sender ID via graph.instagram.com.
  */
-async function getInstagramName(userId) {
-  const accessToken = process.env.META_ACCESS_TOKEN;
+async function getInstagramName(userId, creds) {
+  const accessToken = creds?.accessToken || process.env.META_ACCESS_TOKEN;
   const res = await fetch(
-    `https://graph.facebook.com/v18.0/${userId}?fields=name&access_token=${accessToken}`
+    `https://graph.instagram.com/v21.0/${userId}?fields=name,username&access_token=${accessToken}`
   );
   if (!res.ok) return null;
   const data = await res.json();
-  return data.name || null;
+  return data.name || data.username || null;
 }
 
-module.exports = { handleWebhook, sendInstagramMessage };
+module.exports = { verifyWebhook, handleWebhook, sendInstagramMessage };


### PR DESCRIPTION
## Primary fix — production bug breaking GM_CONFIG
`vercel.json` `cleanUrls` 308-redirects `/api/config.js` → `/api/config`, but the API only matched `/api/config.js`, so the redirected request **404s**. Result: `window.GM_CONFIG` never loads on any page →
- **login** breaks (Supabase anon key missing)
- **WhatsApp/Instagram one-click connect** breaks (`whatsappConfigId` / `facebookAppId` undefined → "not configured")

Verified live: `curl /api/config.js` → 308 → `/api/config` → 404. Fix accepts both paths.

## Secondary — Instagram channel correctness (for when it's enabled later)
- `sendInstagramMessage` → `graph.instagram.com/v21.0/me/messages` (Instagram-Login model; was wrongly on `graph.facebook.com`)
- `getInstagramName` → `graph.instagram.com`, per-business creds
- `verifyWebhook` with real `hub.verify_token` check (exported)
- Instagram dashboard badge kept **"Soon"** (gated until Meta App Review — not misrepresented as Live)
- `.gitignore` `*.bak` + GDPR-sensitive `OUTREACH-TARGETS.md`

## Verified against prod
- `/api/health` → all services `true` ✅
- WhatsApp webhook → 403 on bad token ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)